### PR TITLE
Fixed hover on server names for icons

### DIFF
--- a/src/css/RegisterLog.css
+++ b/src/css/RegisterLog.css
@@ -57,9 +57,7 @@ button {
   margin-top: 1rem;
 }
 
-button {
-  padding: 0.5rem;
-}
+
 
 .instructions {
     font-size: 0.75rem;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -81,23 +81,58 @@
     .serverStatus{
         @apply rounded-full bg-white w-2 h-2 relative right-6 top-[75px] z-10
     }
-    .gameRoom{
-        display:flex;
-        width:100px;
-        height:100px;
+
+.icon-button{
+    display: block;
+    width: 40px;
+    height: 40px;
+    margin: 20px 20px 20px 20px;
+    
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+.icons{
+        position: absolute;
+    top: -30%;
+    right: -70px; /* Adjust this value for icon positioning */
+  
+    z-index:1;
+    border-left: none;
+    display: none;
+}
+.icons:hover{color:white}
+
+.mainHover{
+    padding: 0px 0px 0px 0px;
+    display: inline-block;
+    cursor: pointer;
+}
+    .gameRoomContainer{
+position: relative;
+width:100px;
+    display: inline-block;
+      height:100px;
         text-align:center;
         justify-content:center;
         align-self:center;
         border:4px solid hsl(321,28%,41%);
-        position:relative;
-        font-size:1rem;
-                   
     }
-    .gameRoom:hover{
+ 
+    .gameRoomContainer:hover .icons {
+    display: block;
+}
+
+    .gameRoomContainer:hover{
         color:#fff;
         transition:0.5s;
-    }
-    .gameRoom::before{
+    } 
+    .gameRoomContainer:hover #exitImage,
+    .gameRoomContainer:hover #muteImage {
+        display: block;
+}
+
+    .gameRoomContainer::before{
         content:'';
         position:absolute;
         top:0;
@@ -110,18 +145,26 @@
         transform:scale(0.5);
         z-index:-1;
     }
-     .gameRoom:hover::before{
+     .gameRoomContainer:hover::before{
         transform:scale(1);
         box-shadow:0 0 20px var(--primary-HighlightDim);
         filter:blue(3px);
-  }  
+    }
+    .gameRoomContainer .content:hover .exitSvg,
+.gameRoomContainer .content:hover img {
+    display: block;
+    
+}
+
+
+
    
     .serverName{
         font-family:var(--primaryFont);
         font-weight:bold;
         font-size:0.8rem;
         line-height:1.1;
-        margin:0px 10px;
+        margin:0px 10px 0px 4px ;
     
     }
     .exitSvg{

--- a/src/pages/Sidebar.js
+++ b/src/pages/Sidebar.js
@@ -47,31 +47,51 @@ const Sidebar = () => {
                 <img src={IconLogo} alt="" /> 
             </button>
             <ul className="flex-col flex my-2 mx-auto text-primaryHighlight list-disc"  >
+
+           
+
                 {/* SERVER ONE */}
                   <span className="serverStatus"></span>
-                <li className="gameRoom my-5 rounded-full list-disc group"onLoad={onFile}>
-                    <img alt="" src={exit} className="exitSvg hidden w-auto h-6 absolute left-[103px;] top-3 group-hover:block"  />
-                  <button  className="serverName"  id="serverOne" ref={servername}>Street Fighter III 3rd Strike:Fight For Japan </button>
-                    <img alt=""  src={mute} className=" hidden w-auto h-6 absolute left-[103px] top-16 group-hover:block" />
-                    
+                <li className="gameRoomContainer my-5 rounded-full list-disc group"onLoad={onFile}>
+                   
+                  
+                  <button  className="serverName mainHover"  id="serverOne" ref={servername}>Street Fighter III 3rd Strike:Fight For Japan </button>
+                     <div className="icons">  
+                        <img alt=""  src={mute} className=" top-16 group-hover:block icon-button" />
+                        <img alt="" src={exit} className=" left-[103px;] top-3 group-hover:block icon-button"  />
+                    </div>
+                 
                 </li>
+
+                
           
 
                 {/* SERVER TWO */}
+             
                 <span className="serverStatus"></span>
-                <li className="gameRoom my-5 rounded-full list-disc group" onLoad={onFile}>
-                    <img alt="" src="exit.svg" className=" hidden w-auto h-6 absolute left-[103px;] top-3 group-hover:block"  />
-                    <button className="serverName" id="serverTwo" ref={secondServer} > The Last Blade 2 / bakumatsu Roman - Dai Ni Maku Gekku No Kenshi  </button>
-                    <img alt=""  src="./mute.svg" className=" hidden w-auto h-6 absolute left-[103px] top-16 group-hover:block" />
-                    
+                <li className="gameRoomContainer my-5 rounded-full list-disc group"onLoad={onFile}>
+                   
+                  
+                  <button  className="serverName mainHover"  id="serverOne" ref={secondServer}>The Last Blade 2 / bakumatsu Roman - Dai Ni Maku Gekku No Kenshi  </button>
+                     <div className="icons">  
+                        <img alt=""  src={mute} className=" top-16 group-hover:block icon-button" />
+                        <img alt="" src={exit} className=" left-[103px;] top-3 group-hover:block icon-button"  />
+                    </div>
+                 
                 </li>
+                
                 {/* SERVER THREE */}
-                <span className="serverStatus"></span>
-                <li className="gameRoom my-5 rounded-full list-disc group" onLoad={onFile}>
-                    <img alt="" src="exit.svg" className=" hidden w-auto h-6 absolute left-[103px;] top-3 group-hover:block"  />
-                  <button className="serverName" id="serverThree" ref={thirdServer} >Rage Of Dragons (NGM -264?) </button>
+               <span className="serverStatus"></span>
+                <li className="gameRoomContainer my-5 rounded-full list-disc group"onLoad={onFile}>
+                   
+                  
                     <img alt=""  src="./mute.svg" className=" hidden w-auto h-6 absolute left-[103px] top-16 group-hover:block" />
-                    
+                  <button  className="serverName mainHover"  id="serverOne" ref={thirdServer}>Rage Of Dragons (NGM -264?) </button>
+                     <div className="icons">  
+                        <img alt=""  src={mute} className=" top-16 group-hover:block icon-button" />
+                        <img alt="" src={exit} className=" left-[103px;] top-3 group-hover:block icon-button"  />
+                    </div>
+                 
                 </li>
                 
                

--- a/src/pages/login.css
+++ b/src/pages/login.css
@@ -64,10 +64,6 @@ button {
   margin-top: 1rem;
 }
 
-button {
-  padding: 0.5rem;
-}
-
 .instructions {
     font-size: 0.75rem;
     border-radius: 0.5rem;


### PR DESCRIPTION
Fixed a bug where the icons would disappear if you moved the mouse away from the pink circle that displays the name of the game.

The solution was to change its html structure and add a large enough margin to the icons container so that the mouse cursor can hover over the icons without having a gap between the icons and the server name. 